### PR TITLE
Add crewAI multi-agent processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,16 @@ print(response)
 
 ## crewAI document analysis
 
-A helper class is provided to process receipts or invoices using the
-[crewAI](https://github.com/joaomdmoura/crewai) agent framework. It creates
-an agent capable of extracting expenses from a piece of text.
-The `CrewDocumentProcessor` will require the optional `crewai` package.
+The project includes a helper class built on top of
+[crewAI](https://github.com/joaomdmoura/crewai).  It now defines two
+agents: one reads a document and extracts the expenses into JSON while the
+second agent stores those expenses into the local SQLite database.  The
+`CrewDocumentProcessor` will require the optional `crewai` package.
 
 ```python
 from python.ai import CrewDocumentProcessor
 
 processor = CrewDocumentProcessor()
-expenses = processor.parse_text("""Receipt\n1/1/2024 Coffee 2.50 EUR""")
+expenses = processor.parse_file("receipt.txt")
 print(expenses)
 ```

--- a/src/python/ai/crew_extractor.py
+++ b/src/python/ai/crew_extractor.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, List
+import json
+import os
+
+from ..dao.money_transfer_dao import MoneyTransferDAO
+from ..dao.db_connection import ConnectionDB
 
 
 class CrewDocumentProcessor:
     """Use crewAI agents to extract expenses from document text."""
 
-    def __init__(self, crew: object | None = None) -> None:
-        """Initialize the processor with an optional pre-configured crew."""
+    def __init__(self, crew: object | None = None, db_path: str | None = None) -> None:
+        """Initialize the processor with an optional pre-configured crew and database."""
         try:
             from crewai import Agent, Crew, Task
         except ImportError as exc:
@@ -21,30 +26,72 @@ class CrewDocumentProcessor:
             self.crew = crew
             return
 
-        expert = Agent(
+        self.db_path = db_path or os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+            "data",
+            "ddl",
+            "debug.db",
+        )
+        self.db_connection = ConnectionDB(db_path=self.db_path)
+
+        def read_file(path: str) -> str:
+            """Tool to read a file and return its contents."""
+            with open(path, "r", encoding="utf-8") as fh:
+                return fh.read()
+
+        def insert_expenses(expenses_json: str) -> int:
+            """Tool to insert expenses into the database."""
+            expenses = json.loads(expenses_json)
+            dao = MoneyTransferDAO(db_path=self.db_path)
+            rows = 0
+            for exp in expenses:
+                rows += dao.create_transfer(
+                    exp.get("date"),
+                    float(exp.get("amount")),
+                    None,
+                    1,
+                    exp.get("description"),
+                )
+            return rows
+
+        extractor = Agent(
             role="expense extraction expert",
             goal="extract each expense from the given document",
             backstory=(
                 "You carefully read receipts and invoices to identify all"
                 " expenses with date, description and amount."
             ),
+            tools=[read_file],
         )
 
-        task = Task(
-            description="Identify all expenses in the document text.",
+        db_agent = Agent(
+            role="database agent",
+            goal="store the extracted expenses into the SQLite database",
+            backstory="You can execute queries on the local database.",
+            tools=[insert_expenses],
+        )
+
+        extract_task = Task(
+            description="Identify all expenses in the document text using the file reader tool.",
             expected_output=(
                 "A JSON array of objects each containing date, description,"
                 " and amount fields"
             ),
+            agent=extractor,
         )
-        #cia
 
-        self.crew = Crew(agents=[expert], tasks=[task])
+        insert_task = Task(
+            description="Insert the extracted expenses into the database using the provided tool.",
+            expected_output="Number of rows inserted",
+            agent=db_agent,
+            context=[extract_task],
+        )
 
-    def parse_text(self, text: str) -> List[Mapping[str, str]]:
-        """Run the crew on ``text`` and return parsed expenses."""
-        result = self.crew.kickoff({"text": text})
+        self.crew = Crew(agents=[extractor, db_agent], tasks=[extract_task, insert_task])
+
+    def parse_file(self, file_path: str) -> List[Mapping[str, str]]:
+        """Run the crew on ``file_path`` and return parsed expenses."""
+        result = self.crew.kickoff({"file_path": file_path})
         if isinstance(result, str):
-            import json
             return json.loads(result)
         return result


### PR DESCRIPTION
## Summary
- extend `CrewDocumentProcessor` with two crewAI agents and DB access
- update README usage example with new method

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889e3961bb0832ab9bea823837becbe