### PR TITLE
Fix crew extractor syntax and handle optional AI imports

### DIFF
--- a/src/python/ai/__init__.py
+++ b/src/python/ai/__init__.py
@@ -1,6 +1,13 @@
 """AI helpers for the monthly budget application."""
 
 from .azure_gpt import AzureGPT4O
-from .crew_extractor import CrewDocumentProcessor
+
+# CrewDocumentProcessor relies on optional third-party packages.  Import it
+# lazily so environments without those heavy dependencies can still use the
+# rest of the ``python.ai`` helpers (e.g., during testing).
+try:  # pragma: no cover - optional dependency
+    from .crew_extractor import CrewDocumentProcessor
+except ModuleNotFoundError:  # pragma: no cover - package not installed
+    CrewDocumentProcessor = None
 
 __all__ = ["AzureGPT4O", "CrewDocumentProcessor"]

--- a/src/python/ai/crew_extractor.py
+++ b/src/python/ai/crew_extractor.py
@@ -54,7 +54,7 @@ def check_sql(sql_query: str) -> str:
     return QuerySQLCheckerTool(db=get_db(), llm=get_llm()).invoke({"query": sql_query})
 
 @CrewBase
-class MoneyTransferOperator(): 
+class CrewDocumentProcessor:
     agents_config = 'config/agents.yaml'
     tasks_config = 'config/tasks.yaml'
     @agent
@@ -70,10 +70,9 @@ class MoneyTransferOperator():
     @agent
     def descriptor(self) -> Agent:
         return Agent(
-        config=self.agents_config['descriptor']
-        llm=get_llm(model="azure/gpt-4o")
-        
-        )    
+            config=self.agents_config['descriptor'],
+            llm=get_llm(model="azure/gpt-4o"),
+        )
  
     @task
     def create_sql(self) -> Agent:
@@ -84,12 +83,12 @@ class MoneyTransferOperator():
     @task
     def describe(self) -> Agent:
         return  Task(
-            config = self.taskss_config['describe_task']
+            config=self.tasks_config['describe_task']
         )
 
     @crew
     def crew(self) -> Crew:
-        """Creates the MoneyTransferOperator crew"""
+        """Creates the CrewDocumentProcessor crew"""
         return Crew(
             agents=self.agents, # Automatically created by the @agent decorator
             tasks=self.tasks, # Automatically created by the @task decorator
@@ -110,6 +109,6 @@ if __name__ == "__main__":
                     }
                 ]
             }
-    crew = MoneyTransferOperator()
-    result = crew.crew().kickoff(inputs=json)
+    processor = CrewDocumentProcessor()
+    result = processor.crew().kickoff(inputs=json)
     print(result)


### PR DESCRIPTION
## Summary
- Fix syntax errors and rename crew extractor class to `CrewDocumentProcessor`
- Guard optional `CrewDocumentProcessor` import so core AI helpers load without extra deps

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install Pillow` *(fails: Could not find a version that satisfies the requirement Pillow)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e44d7554832aac15b47f4641f7e4