### PR TITLE
Add Streamlit UI with savings display and chat

### DIFF
--- a/ui/app.py
+++ b/ui/app.py
@@ -9,58 +9,66 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(PROJECT_ROOT / "src"))
 
 from python.dao.money_transfer_dao import MoneyTransferDAO
+from python.dao.user_dao import UserDAO
 from python.ai.chatbot import ChatBot
 
 # Initialize DAO with database path from env or fallback debug db
 DB_PATH = os.getenv("DB_PATH") or str(PROJECT_ROOT / "data" / "ddl" / "debug.db")
 dao = MoneyTransferDAO(db_path=DB_PATH, env=None)
+user_dao = UserDAO(db_path=DB_PATH, env=None)
 
-
-def get_month_savings(dao: MoneyTransferDAO, start_date: str, end_date: str) -> float:
-    """Return net savings between two dates."""
+def get_month_savings(dao: MoneyTransferDAO, user_id: int, start_date: str, end_date: str) -> float:
+    """Return net savings for a user between two dates."""
     query = (
         """
         SELECT
             COALESCE(SUM(CASE WHEN incoming = 1 THEN amount ELSE 0 END), 0) -
             COALESCE(SUM(CASE WHEN incoming = 0 THEN amount ELSE 0 END), 0)
         FROM money_transfer
-        WHERE date BETWEEN ? AND ?
+        WHERE user_id = ? AND date BETWEEN ? AND ?
         """
     )
-    result = dao.db_connection.execute_query(query, (start_date, end_date))
+    result = dao.db_connection.execute_query(query, (user_id, start_date, end_date))
     return result[0][0] if result else 0.0
-
 
 st.set_page_config(page_title="Monthly Budget", layout="centered")
 page = st.sidebar.selectbox("Seleziona la pagina", ["Homepage", "Chat"])
 
 if page == "Homepage":
     st.title("Risparmi del mese")
-    today = datetime.date.today()
-    month_start = today.replace(day=1)
-    next_month = (month_start + datetime.timedelta(days=32)).replace(day=1)
-    savings = get_month_savings(dao, month_start.isoformat(), next_month.isoformat())
+    users = user_dao.get_all_users()
+    user_options = {f"{u[1]} (id:{u[0]})": u[0] for u in users}
+    if not user_options:
+        st.warning("Nessun utente trovato nel database")
+    else:
+        selected = st.selectbox("Seleziona utente", list(user_options.keys()))
+        user_id = user_options[selected]
 
-    st.markdown(
-        f"""
-        <style>
-        .savings-circle {{
-            width: 200px;
-            height: 200px;
-            border-radius: 50%;
-            background: #4CAF50;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: white;
-            font-size: 2em;
-            margin: auto;
-        }}
-        </style>
-        <div class="savings-circle">{savings:.2f}</div>
-        """,
-        unsafe_allow_html=True,
-    )
+        today = datetime.date.today()
+        month_start = today.replace(day=1)
+        next_month = (month_start + datetime.timedelta(days=32)).replace(day=1)
+        savings = get_month_savings(dao, user_id, month_start.isoformat(), next_month.isoformat())
+
+        st.markdown(
+            f"""
+            <style>
+            .savings-circle {{
+                width: 200px;
+                height: 200px;
+                border-radius: 50%;
+                background: #4CAF50;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                color: white;
+                font-size: 2em;
+                margin: auto;
+            }}
+            </style>
+            <div class=\"savings-circle\">{savings:.2f}</div>
+            """,
+            unsafe_allow_html=True,
+        )
 
 elif page == "Chat":
     st.title("Chat con LLM")


### PR DESCRIPTION
## Summary
- implement Streamlit app to display per-user monthly savings from SQLite DB
- include chat page backed by existing ChatBot class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68a4818dde14832aa1fcc659fbb3c85e